### PR TITLE
Rev2.1 communciations

### DIFF
--- a/lib/sparthan_myo/includes/myo_bluetooth.h
+++ b/lib/sparthan_myo/includes/myo_bluetooth.h
@@ -1,0 +1,428 @@
+#pragma once
+
+// #include <stdint.h>
+
+#if defined(_MSC_VER) || defined(_WIN32)
+#pragma pack(push, 1)
+#define MYOHW_PACKED
+#else
+#define MYOHW_PACKED __attribute__((__packed__))
+#endif  // _MSC_VER
+
+/// Check, at compile time, that the size of \a type is \a size bytes.
+#ifdef __cplusplus
+#define MYOHW_STATIC_ASSERT_SIZED(type, size) \
+  static_assert(sizeof(type) == size, #type " does not have size " #size)
+#else
+#define MYOHW_STATIC_ASSERT_SIZED(type, size)
+#endif
+
+#define MYO_SERVICE_INFO_UUID                                               \
+  {                                                                         \
+    0x42, 0x48, 0x12, 0x4a, 0x7f, 0x2c, 0x48, 0x47, 0xb9, 0xde, 0x04, 0xa9, \
+        0x01, 0x00, 0x06, 0xd5                                              \
+  }
+static const uint8_t kMyoServiceInfoUuid[] = MYO_SERVICE_INFO_UUID;
+
+/// The number of EMG sensors that a Myo has.
+static const int myohw_num_emg_sensors = 8;
+
+/// @defgroup myo_hardware Myo Hardware Data Structures
+/// These types and enumerations describe the format of data sent to and from a
+/// Myo device using Bluetooth Low Energy. All values are big-endian.
+/// @{
+
+/// The following enum lists the 16bit short UUIDs of Myo services and
+/// characteristics. To construct a full 128bit UUID, replace the two 0x00 hex
+/// bytes of MYO_SERVICE_BASE_UUID with a short UUID from
+/// myohw_standard_services. The byte sequence of MYO_SERVICE_BASE_UUID is in
+/// network order. Keep this in mind when doing the replacement. For example,
+/// the full service UUID for GCControlService would be
+/// d5060001-a904-deb9-4748-2c7f4a124842.
+#define MYO_SERVICE_BASE_UUID                                               \
+  {                                                                         \
+    0x42, 0x48, 0x12, 0x4a, 0x7f, 0x2c, 0x48, 0x47, 0xb9, 0xde, 0x04, 0xa9, \
+        0x00, 0x00, 0x06, 0xd5                                              \
+  }
+
+typedef enum {
+  ControlService = 0x0001,  ///< Myo info service
+  MyoInfoCharacteristic =
+      0x0101,  ///< Serial number for this Myo and various parameters which
+               ///< are specific to this firmware. Read-only attribute.
+               ///< See myohw_fw_info_t.
+  FirmwareVersionCharacteristic =
+      0x0201,  ///< Current firmware version. Read-only characteristic.
+               ///< See myohw_fw_version_t.
+  CommandCharacteristic = 0x0401,  ///< Issue commands to the Myo. Write-only
+                                   ///< characteristic. See myohw_command_t.
+
+  ImuDataService = 0x0002,  ///< IMU service
+  IMUDataCharacteristic =
+      0x0402,  ///< See myohw_imu_data_t. Notify-only characteristic.
+  MotionEventCharacteristic =
+      0x0502,  ///< Motion event data. Indicate-only characteristic.
+
+  ClassifierService = 0x0003,  ///< Classifier event service.
+  ClassifierEventCharacteristic =
+      0x0103,  ///< Classifier event data. Indicate-only characteristic. See
+               ///< myohw_pose_t.
+
+  EmgDataService = 0x0005,  ///< Raw EMG data service.
+  EmgData0Characteristic =
+      0x0105,  ///< Raw EMG data. Notify-only characteristic.
+  EmgData1Characteristic =
+      0x0205,  ///< Raw EMG data. Notify-only characteristic.
+  EmgData2Characteristic =
+      0x0305,  ///< Raw EMG data. Notify-only characteristic.
+  EmgData3Characteristic =
+      0x0405,  ///< Raw EMG data. Notify-only characteristic.
+} myohw_services;
+
+// Standard Bluetooth device services.
+typedef enum {
+  BatteryService = 0x180f,              ///< Battery service
+  BatteryLevelCharacteristic = 0x2a19,  ///< Current battery level information.
+                                        ///< Read/notify characteristic.
+
+  DeviceName = 0x2a00,  ///< Device name data. Read/write characteristic.
+} myohw_standard_services;
+
+/// Supported poses.
+typedef enum {
+  myohw_pose_rest = 0x0000,
+  myohw_pose_fist = 0x0001,
+  myohw_pose_wave_in = 0x0002,
+  myohw_pose_wave_out = 0x0003,
+  myohw_pose_fingers_spread = 0x0004,
+  myohw_pose_double_tap = 0x0005,
+  myohw_pose_unknown = 0xffff
+} myohw_pose_t;
+
+/// Various parameters that may affect the behaviour of this Myo armband.
+/// The Myo library reads this attribute when a connection is established.
+/// Value layout for the myohw_att_handle_fw_info attribute.
+typedef struct MYOHW_PACKED {
+  uint8_t serial_number[6];  ///< Unique serial number of this Myo.
+  uint16_t unlock_pose;      ///< Pose that should be interpreted as the unlock
+                             ///< pose. See myohw_pose_t.
+  uint8_t active_classifier_type;  ///< Whether Myo is currently using a
+                                   ///< built-in or a custom classifier. See
+                                   ///< myohw_classifier_model_type_t.
+  uint8_t active_classifier_index;  ///< Index of the classifier that is
+                                    ///< currently active.
+  uint8_t has_custom_classifier;    ///< Whether Myo contains a valid custom
+                                    ///< classifier. 1 if it does, otherwise 0.
+  uint8_t stream_indicating;  ///< Set if the Myo uses BLE indicates to stream
+                              ///< data, for reliable capture.
+  uint8_t sku;                ///< SKU value of the device. See myohw_sku_t
+  uint8_t reserved[7];  ///< Reserved for future use; populated with zeros.
+} myohw_fw_info_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_fw_info_t, 20);
+
+// Known Myo SKUs
+typedef enum {
+  myohw_sku_unknown = 0,    ///< Unknown SKU (default value for old firmwares)
+  myohw_sku_black_myo = 1,  ///< Black Myo
+  myohw_sku_white_myo = 2   ///< White Myo
+} myohw_sku_t;
+
+/// Known Myo hardware revisions.
+typedef enum {
+  myohw_hardware_rev_unknown = 0,  ///< Unknown hardware revision.
+  myohw_hardware_rev_revc = 1,     ///< Myo Alpha (REV-C) hardware.
+  myohw_hardware_rev_revd = 2,     ///< Myo (REV-D) hardware.
+  myohw_num_hardware_revs  ///< Number of hardware revisions known; not a valid
+                           ///< hardware revision.
+} myohw_hardware_rev_t;
+
+/// Version information for the Myo firmware.
+/// Value layout for the myohw_att_handle_fw_version attribute.
+/// Minor version is incremented for changes in this interface.
+/// Patch version is incremented for firmware changes that do not introduce
+/// changes in this interface.
+typedef struct MYOHW_PACKED {
+  uint16_t major;
+  uint16_t minor;
+  uint16_t patch;
+  uint16_t hardware_rev;  ///< Myo hardware revision. See myohw_hardware_rev_t.
+} myohw_fw_version_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_fw_version_t, 8);
+
+#define MYOHW_FIRMWARE_VERSION_MAJOR 1
+#define MYOHW_FIRMWARE_VERSION_MINOR 2
+static const uint16_t myohw_firmware_version_major =
+    MYOHW_FIRMWARE_VERSION_MAJOR;
+static const uint16_t myohw_firmware_version_minor =
+    MYOHW_FIRMWARE_VERSION_MINOR;
+
+/// @defgroup myohw_control_commands Control Commands
+/// @{
+
+/// Kinds of commands.
+typedef enum {
+  myohw_command_set_mode =
+      0x01,  ///< Set EMG and IMU modes. See myohw_command_set_mode_t.
+  myohw_command_vibrate = 0x03,  ///< Vibrate. See myohw_command_vibrate_t.
+  myohw_command_deep_sleep =
+      0x04,  ///< Put Myo into deep sleep. See myohw_command_deep_sleep_t.
+  myohw_command_vibrate2 =
+      0x07,  ///< Extended vibrate. See myohw_command_vibrate2_t.
+  myohw_command_set_sleep_mode =
+      0x09,  ///< Set sleep mode. See myohw_command_set_sleep_mode_t.
+  myohw_command_unlock = 0x0a,  ///< Unlock Myo. See myohw_command_unlock_t.
+  myohw_command_user_action =
+      0x0b,  ///< Notify user that an action has been recognized / confirmed.
+             ///< See myohw_command_user_action_t.
+} myohw_command_t;
+
+/// Header that every command begins with.
+typedef struct MYOHW_PACKED {
+  uint8_t command;       ///< Command to send. See myohw_command_t.
+  uint8_t payload_size;  ///< Number of bytes in payload.
+} myohw_command_header_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_command_header_t, 2);
+
+/// EMG modes.
+typedef enum {
+  myohw_emg_mode_none = 0x00,          ///< Do not send EMG data.
+  myohw_emg_mode_send_emg = 0x02,      ///< Send filtered EMG data.
+  myohw_emg_mode_send_emg_raw = 0x03,  ///< Send raw (unfiltered) EMG data.
+} myohw_emg_mode_t;
+
+/// IMU modes.
+typedef enum {
+  myohw_imu_mode_none = 0x00,       ///< Do not send IMU data or events.
+  myohw_imu_mode_send_data = 0x01,  ///< Send IMU data streams (accelerometer,
+                                    ///< gyroscope, and orientation).
+  myohw_imu_mode_send_events =
+      0x02,  ///< Send motion events detected by the IMU (e.g. taps).
+  myohw_imu_mode_send_all =
+      0x03,  ///< Send both IMU data streams and motion events.
+  myohw_imu_mode_send_raw = 0x04,  ///< Send raw IMU data streams.
+} myohw_imu_mode_t;
+
+/// Classifier modes.
+typedef enum {
+  myohw_classifier_mode_disabled = 0x00,  ///< Disable and reset the internal
+                                          ///< state of the onboard classifier.
+  myohw_classifier_mode_enabled =
+      0x01,  ///< Send classifier events (poses and arm events).
+} myohw_classifier_mode_t;
+
+/// Command to set EMG and IMU modes.
+typedef struct MYOHW_PACKED {
+  myohw_command_header_t
+      header;        ///< command == myohw_command_set_mode. payload_size = 3.
+  uint8_t emg_mode;  ///< EMG sensor mode. See myohw_emg_mode_t.
+  uint8_t imu_mode;  ///< IMU mode. See myohw_imu_mode_t.
+  uint8_t classifier_mode;  ///< Classifier mode. See myohw_classifier_mode_t.
+} myohw_command_set_mode_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_command_set_mode_t, 5);
+
+/// Kinds of vibrations.
+typedef enum {
+  myohw_vibration_none = 0x00,    ///< Do not vibrate.
+  myohw_vibration_short = 0x01,   ///< Vibrate for a short amount of time.
+  myohw_vibration_medium = 0x02,  ///< Vibrate for a medium amount of time.
+  myohw_vibration_long = 0x03,    ///< Vibrate for a long amount of time.
+} myohw_vibration_type_t;
+
+/// Vibration command.
+typedef struct MYOHW_PACKED {
+  myohw_command_header_t
+      header;    ///< command == myohw_command_vibrate. payload_size == 1.
+  uint8_t type;  ///< See myohw_vibration_type_t.
+} myohw_command_vibrate_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_command_vibrate_t, 3);
+
+/// Deep sleep command.
+typedef struct MYOHW_PACKED {
+  myohw_command_header_t
+      header;  ///< command == myohw_command_deep_sleep. payload_size == 0.
+} myohw_command_deep_sleep_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_command_deep_sleep_t, 2);
+
+/// Extended vibration command.
+#define MYOHW_COMMAND_VIBRATE2_STEPS 6
+typedef struct MYOHW_PACKED {
+  myohw_command_header_t
+      header;  ///< command == myohw_command_vibrate2. payload_size == 18.
+  struct MYOHW_PACKED {
+    uint16_t duration;  ///< duration (in ms) of the vibration
+    uint8_t
+        strength;  ///< strength of vibration (0 - motor off, 255 - full speed)
+  } steps[MYOHW_COMMAND_VIBRATE2_STEPS];
+} myohw_command_vibrate2_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_command_vibrate2_t, 20);
+
+/// Sleep modes.
+typedef enum {
+  myohw_sleep_mode_normal =
+      0,  ///< Normal sleep mode; Myo will sleep after a period of inactivity.
+  myohw_sleep_mode_never_sleep = 1,  ///< Never go to sleep.
+} myohw_sleep_mode_t;
+
+/// Set sleep mode command.
+typedef struct MYOHW_PACKED {
+  myohw_command_header_t
+      header;  ///< command == myohw_command_set_sleep_mode. payload_size == 1.
+  uint8_t sleep_mode;  ///< Sleep mode. See myohw_sleep_mode_t.
+} myohw_command_set_sleep_mode_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_command_set_sleep_mode_t, 3);
+
+/// Unlock types.
+typedef enum {
+  myohw_unlock_lock = 0x00,   ///< Re-lock immediately.
+  myohw_unlock_timed = 0x01,  ///< Unlock now and re-lock after a fixed timeout.
+  myohw_unlock_hold = 0x02,   ///< Unlock now and remain unlocked until a lock
+                              ///< command is received.
+} myohw_unlock_type_t;
+
+/// Unlock Myo command.
+/// Can also be used to force Myo to re-lock.
+typedef struct MYOHW_PACKED {
+  myohw_command_header_t
+      header;    ///< command == myohw_command_unlock. payload_size == 1.
+  uint8_t type;  ///< Unlock type. See myohw_unlock_type_t.
+} myohw_command_unlock_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_command_unlock_t, 3);
+
+/// User action types.
+typedef enum {
+  myohw_user_action_single =
+      0,  ///< User did a single, discrete action, such as pausing a video.
+} myohw_user_action_type_t;
+
+/// User action command.
+typedef struct MYOHW_PACKED {
+  myohw_command_header_t
+      header;    ///< command == myohw_command_user_action. payload_size == 1.
+  uint8_t type;  ///< Type of user action that occurred. See
+                 ///< myohw_user_action_type_t.
+} myohw_command_user_action_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_command_user_action_t, 3);
+
+/// Classifier model types
+typedef enum {
+  myohw_classifier_model_builtin =
+      0,  ///< Model built into the classifier package.
+  myohw_classifier_model_custom = 1  ///< Model based on personalized user data.
+} myohw_classifier_model_type_t;
+
+/// @}
+
+/// Integrated motion data.
+typedef struct MYOHW_PACKED {
+  /// Orientation data, represented as a unit quaternion. Values are multiplied
+  /// by MYOHW_ORIENTATION_SCALE.
+  struct MYOHW_PACKED {
+    int16_t w, x, y, z;
+  } orientation;
+
+  int16_t accelerometer[3];  ///< Accelerometer data. In units of g. Range of +
+                             ///< -16. Values are multiplied by
+                             ///< MYOHW_ACCELEROMETER_SCALE.
+  int16_t
+      gyroscope[3];  ///< Gyroscope data. In units of deg/s. Range of + -2000.
+                     ///< Values are multiplied by MYOHW_GYROSCOPE_SCALE.
+} myohw_imu_data_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_imu_data_t, 20);
+
+/// Default IMU sample rate in Hz.
+#define MYOHW_DEFAULT_IMU_SAMPLE_RATE 50
+
+/// Scale values for unpacking IMU data
+#define MYOHW_ORIENTATION_SCALE 16384.0f  ///< See myohw_imu_data_t::orientation
+#define MYOHW_ACCELEROMETER_SCALE \
+  2048.0f                            ///< See myohw_imu_data_t::accelerometer
+#define MYOHW_GYROSCOPE_SCALE 16.0f  ///< See myohw_imu_data_t::gyroscope
+
+/// Types of motion events.
+typedef enum {
+  myohw_motion_event_tap = 0x00,
+} myohw_motion_event_type_t;
+
+/// Motion event data received in a myohw_att_handle_motion_event attribute.
+typedef struct MYOHW_PACKED {
+  uint8_t type;  /// Type type of motion event that occurred. See
+                 /// myohw_motion_event_type_t.
+
+  /// Event-specific data.
+  union MYOHW_PACKED {
+    /// For myohw_motion_event_tap events.
+    struct MYOHW_PACKED {
+      uint8_t tap_direction;
+      uint8_t tap_count;
+    };
+  };
+} myohw_motion_event_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_motion_event_t, 3);
+
+/// Types of classifier events.
+typedef enum {
+  myohw_classifier_event_arm_synced = 0x01,
+  myohw_classifier_event_arm_unsynced = 0x02,
+  myohw_classifier_event_pose = 0x03,
+  myohw_classifier_event_unlocked = 0x04,
+  myohw_classifier_event_locked = 0x05,
+  myohw_classifier_event_sync_failed = 0x06,
+} myohw_classifier_event_type_t;
+
+/// Enumeration identifying a right arm or left arm.
+typedef enum {
+  myohw_arm_right = 0x01,
+  myohw_arm_left = 0x02,
+  myohw_arm_unknown = 0xff
+} myohw_arm_t;
+
+/// Possible directions for Myo's +x axis relative to a user's arm.
+typedef enum {
+  myohw_x_direction_toward_wrist = 0x01,
+  myohw_x_direction_toward_elbow = 0x02,
+  myohw_x_direction_unknown = 0xff
+} myohw_x_direction_t;
+
+/// Possible outcomes when the user attempts a sync gesture.
+typedef enum {
+  myohw_sync_failed_too_hard = 0x01,  ///< Sync gesture was performed too hard.
+} myohw_sync_result_t;
+
+/// Classifier event data received in a myohw_att_handle_classifier_event
+/// attribute.
+typedef struct MYOHW_PACKED {
+  uint8_t type;  ///< See myohw_classifier_event_type_t
+
+  /// Event-specific data
+  union MYOHW_PACKED {
+    /// For myohw_classifier_event_arm_synced events.
+    struct MYOHW_PACKED {
+      uint8_t arm;          ///< See myohw_arm_t
+      uint8_t x_direction;  ///< See myohw_x_direction_t
+    };
+
+    /// For myohw_classifier_event_pose events.
+    uint16_t pose;  ///< See myohw_pose_t
+
+    /// For myohw_classifier_event_sync_failed events.
+    uint8_t sync_result;  ///< See myohw_sync_result_t.
+  };
+} myohw_classifier_event_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_classifier_event_t, 3);
+
+/// The rate that EMG events are streamed over Bluetooth.
+#define MYOHW_EMG_DEFAULT_STREAMING_RATE 200
+
+/// Raw EMG data received in a myohw_att_handle_emg_data_# attribute.
+/// Value layout for myohw_att_handle_emg_data_#.
+typedef struct MYOHW_PACKED {
+  int8_t sample1[8];  ///< 1st sample of EMG data.
+  int8_t sample2[8];  ///< 2nd sample of EMG data.
+} myohw_emg_data_t;
+MYOHW_STATIC_ASSERT_SIZED(myohw_emg_data_t, 16);
+
+/// @}
+
+#if defined(_MSC_VER) || defined(_WIN32)
+#pragma pack(pop)
+#endif  // _MSC_VER

--- a/lib/sparthan_myo/myo.cpp
+++ b/lib/sparthan_myo/myo.cpp
@@ -1,0 +1,298 @@
+#include "myo.h"
+
+/* ENABLE SERIAL DEBUGGING BY SETTING myo.debug = true, **REQUIRES
+ * Serial.begin()** */
+
+// The remote service we wish to connect to.
+static BLEUUID serviceUUID("d5060001-a904-deb9-4748-2c7f4a124842");
+static BLERemoteCharacteristic* pRemoteCharacteristic;
+static BLEAddress* pServerAddress;
+
+// Initialize status variables
+boolean armband::connected = false;
+boolean armband::detected = false;
+boolean armband::debug = false;
+
+/********************************************************************************************************
+    BLUETOOTH CALLBACKS
+ ********************************************************************************************************/
+
+// Scan for BLE servers and find the first one that advertises the Myo ID
+// service
+class MyoAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
+  // Called for each advertising BLE server.
+  void onResult(BLEAdvertisedDevice advertisedDevice) {
+    armband::debug ? Serial.print("BLE Advertised Device found: ") : 0;
+    armband::debug ? Serial.println(advertisedDevice.toString().c_str()) : 0;
+
+    // We have found a Myo, check if it contains the service ID we are looking
+    // for.
+    if (advertisedDevice.haveServiceUUID() &&
+        advertisedDevice.getServiceUUID().equals(serviceUUID)) {
+      armband::debug ? Serial.print(" - Myo device found") : 0;
+      // Stop scanning
+      advertisedDevice.getScan()->stop();
+      // Save the address of the current Myo
+      pServerAddress = new BLEAddress(advertisedDevice.getAddress());
+      // Update detection status
+      armband::detected = true;
+    }
+  }
+};
+
+// Set the connect and disconnect behaviours
+class MyoClientCallbacks : public BLEClientCallbacks {
+  void onConnect(BLEClient* pClient) {
+    // Update connection status
+    armband::connected = true;
+  }
+  void onDisconnect(BLEClient* pClient) {
+    // Update connection status
+    armband::connected = false;
+    // Update detection status
+    armband::detected = false;
+    // Disconnect the clinet
+    pClient->disconnect();
+    // Clean the BLE stack for a new connection
+    delete pClient;
+  }
+};
+
+/********************************************************************************************************
+    CONNECTION
+ ********************************************************************************************************/
+
+bool connectToServer(BLEClient* pClient, BLEAddress pAddress) {
+  if (armband::debug) {
+    Serial.print("Forming a connection to ");
+    Serial.println(pAddress.toString().c_str());
+  }
+
+  // Connect to the remove BLE Server.
+  pClient->connect(pAddress);
+
+  // Obtain a reference to the service we are after in the remote BLE server.
+  BLERemoteService* pRemoteService = pClient->getService(serviceUUID);
+  if (pRemoteService == nullptr) {
+    if (armband::debug) {
+      Serial.print("Failed to find our service UUID: ");
+      Serial.println(serviceUUID.toString().c_str());
+    }
+    return false;
+  }
+
+  if (armband::debug) {
+    Serial.println(" - Found our service");
+  }
+
+  return true;
+}
+
+void armband::connect() {
+  if (!armband::connected) {
+    // Initialize BLE scan
+    BLEDevice::init("");
+    BLEScan* pBLEScan = BLEDevice::getScan();
+    // Set callbacks for finding devices
+    pBLEScan->setAdvertisedDeviceCallbacks(new MyoAdvertisedDeviceCallbacks());
+    // Active scan uses more power, but get results faster
+    pBLEScan->setActiveScan(true);
+
+    // Keep scanning untill a Myo is detected
+    while (!armband::detected) {
+      pBLEScan->start(10);
+    }
+    // Create new client and set up callbacks
+    armband::pClient = BLEDevice::createClient();
+    armband::pClient->setClientCallbacks(new MyoClientCallbacks());
+
+    // Attempt Server connection
+    connectToServer(armband::pClient, *pServerAddress);
+  }
+}
+
+/********************************************************************************************************
+    INFO
+ ********************************************************************************************************/
+
+void armband::get_info() {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060001-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic = BLEUUID("d5060101-a904-deb9-4748-2c7f4a124842");
+    std::string stringt;
+    stringt = armband::pClient->getService(tservice)
+                  ->getCharacteristic(tcharacteristic)
+                  ->readValue();
+    armband::fw_serial_number[0] = stringt[0];
+    armband::fw_serial_number[1] = stringt[1];
+    armband::fw_serial_number[2] = stringt[2];
+    armband::fw_serial_number[3] = stringt[3];
+    armband::fw_serial_number[4] = stringt[4];
+    armband::fw_serial_number[5] = stringt[5];
+    armband::fw_serial_number[6] = stringt[6];
+    armband::fw_unlock_pose = (byte)stringt[8] * 256 + (byte)stringt[7];
+    armband::fw_active_classifier_type = stringt[9];
+    armband::fw_active_classifier_index = stringt[10];
+    armband::fw_has_custom_classifier = stringt[11];
+    armband::fw_stream_indicating = stringt[12];
+    armband::fw_sku = stringt[13];
+    armband::fw_reserved[0] = stringt[14];
+    armband::fw_reserved[1] = stringt[15];
+    armband::fw_reserved[2] = stringt[16];
+    armband::fw_reserved[3] = stringt[17];
+    armband::fw_reserved[4] = stringt[18];
+    armband::fw_reserved[5] = stringt[19];
+    armband::fw_reserved[6] = stringt[20];
+    armband::fw_reserved[7] = stringt[21];
+  }
+}
+
+void armband::get_firmware() {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060001-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic = BLEUUID("d5060201-a904-deb9-4748-2c7f4a124842");
+    std::string stringt;
+    stringt = armband::pClient->getService(tservice)
+                  ->getCharacteristic(tcharacteristic)
+                  ->readValue();
+    armband::fw_major = (byte)stringt[1] * 256 + (byte)stringt[0];
+    armband::fw_minor = (byte)stringt[3] * 256 + (byte)stringt[2];
+    armband::fw_patch = (byte)stringt[5] * 256 + (byte)stringt[4];
+    armband::fw_hardware_rev = (byte)stringt[7] * 256 + (byte)stringt[6];
+  }
+}
+
+/********************************************************************************************************
+    NOTIFICATIONS
+ ********************************************************************************************************/
+
+BLERemoteCharacteristic* armband::emg_notification(uint8_t on_off) {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060005-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic0 = BLEUUID("d5060105-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic1 = BLEUUID("d5060205-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic2 = BLEUUID("d5060305-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic3 = BLEUUID("d5060405-a904-deb9-4748-2c7f4a124842");
+    uint8_t NotifyOn[] = {on_off, 0x00};
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic0)
+        ->getDescriptor((uint16_t)0x2902)
+        ->writeValue((uint8_t*)NotifyOn, sizeof(NotifyOn), true);
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic1)
+        ->getDescriptor((uint16_t)0x2902)
+        ->writeValue((uint8_t*)NotifyOn, sizeof(NotifyOn), true);
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic2)
+        ->getDescriptor((uint16_t)0x2902)
+        ->writeValue((uint8_t*)NotifyOn, sizeof(NotifyOn), true);
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic3)
+        ->getDescriptor((uint16_t)0x2902)
+        ->writeValue((uint8_t*)NotifyOn, sizeof(NotifyOn), true);
+    return armband::pClient->getService(BLEUUID(tservice))
+        ->getCharacteristic(BLEUUID(tcharacteristic0));
+  }
+}
+
+BLERemoteCharacteristic* armband::imu_notification(uint8_t on_off) {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060002-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic = BLEUUID("d5060402-a904-deb9-4748-2c7f4a124842");
+    uint8_t NotifyOn[] = {on_off, 0x00};
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic)
+        ->getDescriptor((uint16_t)0x2902)
+        ->writeValue((uint8_t*)NotifyOn, sizeof(NotifyOn), true);
+    return armband::pClient->getService(BLEUUID(tservice))
+        ->getCharacteristic(BLEUUID(tcharacteristic));
+  }
+}
+
+BLERemoteCharacteristic* armband::battery_notification(uint8_t on_off) {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("0000180f-0000-1000-8000-00805f9b34fb");
+    BLEUUID tcharacteristic = BLEUUID("00002a19-0000-1000-8000-00805f9b34fb");
+    uint8_t NotifyOn[] = {on_off, 0x00};
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic)
+        ->getDescriptor((uint16_t)0x2902)
+        ->writeValue((uint8_t*)NotifyOn, sizeof(NotifyOn), true);
+    return armband::pClient->getService(BLEUUID(tservice))
+        ->getCharacteristic(BLEUUID(tcharacteristic));
+  }
+}
+
+BLERemoteCharacteristic* armband::gesture_notification(uint8_t on_off) {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060003-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic = BLEUUID("d5060103-a904-deb9-4748-2c7f4a124842");
+    uint8_t IndicateOn[] = {2 * on_off, 0x00};
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic)
+        ->getDescriptor(((uint16_t)0x2902))
+        ->writeValue((uint8_t*)IndicateOn, sizeof(IndicateOn), true);
+    return armband::pClient->getService(BLEUUID(tservice))
+        ->getCharacteristic(BLEUUID(tcharacteristic));
+  }
+}
+
+/********************************************************************************************************
+    COMMANDS
+ ********************************************************************************************************/
+
+void armband::set_myo_mode(uint8_t emg_mode, uint8_t imu_mode,
+                           uint8_t clf_mode) {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060001-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic = BLEUUID("d5060401-a904-deb9-4748-2c7f4a124842");
+    uint8_t writeVal[] = {0x01, 0x03, emg_mode, imu_mode, clf_mode};
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic)
+        ->writeValue(writeVal, sizeof(writeVal));
+  }
+}
+
+void armband::set_sleep_mode(uint8_t sleep_mode) {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060001-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic = BLEUUID("d5060401-a904-deb9-4748-2c7f4a124842");
+    uint8_t writeVal[] = {0x09, 0x01, sleep_mode};
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic)
+        ->writeValue(writeVal, sizeof(writeVal));
+  }
+}
+
+void armband::vibration(uint8_t duration) {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060001-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic = BLEUUID("d5060401-a904-deb9-4748-2c7f4a124842");
+    uint8_t writeVal[] = {0x03, 0x01, duration};
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic)
+        ->writeValue(writeVal, sizeof(writeVal));
+  }
+}
+
+void armband::user_action(uint8_t action_type) {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060001-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic = BLEUUID("d5060401-a904-deb9-4748-2c7f4a124842");
+    uint8_t writeVal[] = {myohw_command_user_action, 0x01, action_type};
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic)
+        ->writeValue(writeVal, sizeof(writeVal));
+  }
+}
+
+void armband::unlock(uint8_t unlock_mode) {
+  if (armband::connected) {
+    BLEUUID tservice = BLEUUID("d5060001-a904-deb9-4748-2c7f4a124842");
+    BLEUUID tcharacteristic = BLEUUID("d5060401-a904-deb9-4748-2c7f4a124842");
+    uint8_t writeVal[] = {0x0a, 0x01, unlock_mode};
+    armband::pClient->getService(tservice)
+        ->getCharacteristic(tcharacteristic)
+        ->writeValue(writeVal, sizeof(writeVal));
+  }
+}

--- a/lib/sparthan_myo/myo.h
+++ b/lib/sparthan_myo/myo.h
@@ -1,0 +1,55 @@
+
+#ifndef myo_h
+#define myo_h
+
+#include <BLEDevice.h>
+
+#include "Arduino.h"
+#include "includes/myo_bluetooth.h"
+
+#define TURN_OFF 0x00
+#define TURN_ON 0x01
+
+class armband {
+ public:
+  void connect();
+
+  void get_info();
+  void get_firmware();
+
+  void set_myo_mode(uint8_t, uint8_t, uint8_t);
+  void vibration(uint8_t);
+  void user_action(uint8_t);
+  void set_sleep_mode(uint8_t);
+  void unlock(uint8_t);
+
+  BLERemoteCharacteristic* emg_notification(uint8_t);
+  BLERemoteCharacteristic* imu_notification(uint8_t);
+  BLERemoteCharacteristic* battery_notification(uint8_t);
+  BLERemoteCharacteristic* gesture_notification(uint8_t);
+
+  BLEClient* pClient;
+
+  // Static status variables that can be used in callbacks
+  static bool connected;
+  static bool detected;
+  static bool debug;
+
+  uint16_t fw_major;
+  uint16_t fw_minor;
+  uint16_t fw_patch;
+  uint16_t fw_hardware_rev;
+  uint8_t fw_serial_number[6];
+  uint16_t fw_unlock_pose;
+  uint8_t fw_active_classifier_type;
+  uint8_t fw_active_classifier_index;
+  uint8_t fw_has_custom_classifier;
+  uint8_t fw_stream_indicating;
+  uint8_t fw_sku;
+  uint8_t fw_reserved[7];
+  uint8_t battery;
+
+ private:
+};
+
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,4 +14,4 @@ platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
 monitor_speed = 115200
-;monitor_filters = esp32_exception_decoder, time, colorize
+monitor_filters = esp32_exception_decoder, time, colorize

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,4 +14,4 @@ platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
 monitor_speed = 115200
-monitor_filters = esp32_exception_decoder, time, colorize
+;monitor_filters = esp32_exception_decoder, time, colorize

--- a/src/Config.h
+++ b/src/Config.h
@@ -9,7 +9,7 @@
  */
 
 // Sets max buffer size to 5 seconds, 1 sec = 100 samples
-#define MAX_BUFFER_SIZE 499
+#define MAX_BUFFER_SIZE 250
 
 // Defines Constant for PWM Channels
 // Used to identify which finger an object is to operate on
@@ -19,8 +19,13 @@
 #define FINGER_RING_CHANNEL 3
 #define FINGER_PINKY_CHANNEL 4
 
-// Saftey Threshold for Servo Current Consumption
-#define MAX_SERVO_CURRENT 930  // 300 mA maximum current draw per servo motor
+// Safety Threshold for Servo Current Consumption
+#define MAX_SERVO_CURRENT 300  // 300 mA maximum current draw per servo motor
+
+// Defines constants for hand position selections
+#define HAND_POSITION_PLATFORM_PUSH 0
+#define HAND_POSITION_LARGE_DIAMETER 1
+#define HAND_POSITION_INDEX_FINGER_POINTING 2
 
 // Buffer structure for storing EMG data
 struct buffer {

--- a/src/Config.h
+++ b/src/Config.h
@@ -24,12 +24,12 @@
 
 // Buffer structure for storing EMG data
 struct buffer {
-  uint16_t myo1;
-  uint16_t myo2;
-  //   uint16_t myo3;
-  //   uint16_t myo4;
-  //   uint16_t myo5;
-  //   uint16_t myo6;
-  //   uint16_t myo7;
-  //   uint16_t myo8;
+  int8_t myo1;
+  int8_t myo2;
+  int8_t myo3;
+  int8_t myo4;
+  int8_t myo5;
+  int8_t myo6;
+  int8_t myo7;
+  int8_t myo8;
 };

--- a/src/PACServoDriver/PACServoDriver.cpp
+++ b/src/PACServoDriver/PACServoDriver.cpp
@@ -177,3 +177,14 @@ bool PACServoDriver::chkBlocked(uint8_t finger) {
   // If finger is not know, return true to prevent finger from being driven
   return true;
 }
+
+/**
+ * @brief Sets duty cycle of all servos to 0 for calibration. This causes the
+ *        servos to draw negligible current values
+ *
+ */
+void PACServoDriver::calibration() {
+  for (uint8_t i = 0; i < 4; i++) {
+    setDutyCycle(i, 0);
+  }
+}

--- a/src/PACServoDriver/PACServoDriver.h
+++ b/src/PACServoDriver/PACServoDriver.h
@@ -21,9 +21,9 @@
 #define FINGER_PINKY_CHANNEL 4
 
 // Defines Drive limits for servos
-#define SERVO_HOME 50  // 20% duty cycle @8 bit resolution
-#define SERVO_Max 205  // 80% duty cycle @8 bit resolution
-#define SERVO_STOP 0   // Servos Stop moving and freeze in place
+#define SERVO_HOME 100  // 20% duty cycle @8 bit resolution
+#define SERVO_Max 205   // 80% duty cycle @8 bit resolution
+#define SERVO_STOP 0    // Servos Stop moving and freeze in place
 
 // Max Distance Drivable
 // This limits the distance each finger can drive as each finger in unique

--- a/src/PACServoDriver/PACServoDriver.h
+++ b/src/PACServoDriver/PACServoDriver.h
@@ -75,4 +75,5 @@ class PACServoDriver {
 
   // utility functions
   void setDriveSpeed(uint8_t speed);
+  void calibration();
 };

--- a/src/SPICurrentSense/MAX11629_SPICommands.h
+++ b/src/SPICurrentSense/MAX11629_SPICommands.h
@@ -35,11 +35,11 @@ Setup Register
 // Sampling Clock Select pin 8 = CVNST
 #define INTERNAL_CVST 0b01000000  // Conversion & acquisition internally clock
 // Conversion internally clock, Acquisition externally clock
-#define INTERNAL_EXTERNAL_CVST 0b010001000
+#define INTERNAL_EXTERNAL_CVST 0b010100000
 
 // Sampling Clock Select pin 8 = AIN7
-#define INTERNAL_CLK 0b01001000  // Conversion & acquisition internally clock
-#define EXTERNAL_CLK 0b01001100  // Conversion & acquisition externally clock
+#define INTERNAL_CLK 0b01100000  // Conversion & acquisition internally clock
+#define EXTERNAL_CLK 0b01110000  // Conversion & acquisition externally clock
 
 // Voltage Reference Select
 #define INTERNAL_WAKEUP 0b01000000  // Internal reference, wake-up delay

--- a/src/SPICurrentSense/MAX11629_SPICommands.h
+++ b/src/SPICurrentSense/MAX11629_SPICommands.h
@@ -1,0 +1,78 @@
+/*
+ *  Prosthetic Arm Control (P.A.C) MAX11529 SPI Commands
+ *
+ *  Created on: 26 Feb, 2023
+ *      Author: Zachary Roberts
+ *
+ *      This library is used to store and define all of the SPI commands
+ *      required to communicate with the MAX11629EEE+ external SPI ADC. This
+ *      library was created for use with the prosthetic arm created in
+ *      collaboration with York College of Pennsylvania Capstone Course
+ */
+
+/*******************************************************************************
+Conversion Register
+*******************************************************************************/
+// Select Input Channel (N)
+#define AIN0 0b10000000  // Read input from channel 0
+#define AIN1 0b10001000  // Read input from channel 1
+#define AIN2 0b10010000  // Read input from channel 2
+#define AIN3 0b10011000  // Read input from channel 3
+#define AIN4 0b10100000  // Read input from channel 4
+#define AIN5 0b10101000  // Read input from channel 5
+#define AIN6 0b10110000  // Read input from channel 6
+#define AIN7 0b10111000  // Read input from channel 7
+
+// Select Scan Mode
+#define SCAN_0N 0b10000000   // Scans input from channel 0 through N
+#define SCAN_N7 0b10000010   // Scans input from channel N through 7
+#define SCAN_AVG 0b10000100  // Scans channel N repeatedly
+#define SCAN_N 0b10000110    // Scan input from channel N once
+
+/*******************************************************************************
+Setup Register
+*******************************************************************************/
+// Sampling Clock Select pin 8 = CVNST
+#define INTERNAL_CVST 0b01000000  // Conversion & acquisition internally clock
+// Conversion internally clock, Acquisition externally clock
+#define INTERNAL_EXTERNAL_CVST 0b010001000
+
+// Sampling Clock Select pin 8 = AIN7
+#define INTERNAL_CLK 0b01001000  // Conversion & acquisition internally clock
+#define EXTERNAL_CLK 0b01001100  // Conversion & acquisition externally clock
+
+// Voltage Reference Select
+#define INTERNAL_WAKEUP 0b01000000  // Internal reference, wake-up delay
+#define EXTERNAL_VREF 0b01000100    // External reference, no wake up delay
+#define INTERNAL_VREF 0b01001100    // External reference, no wake up delay
+
+/*******************************************************************************
+Averaging Register
+*******************************************************************************/
+// Disable Averaging
+#define AVG_DISABLE 0b00100000
+
+// Enable Averaging
+#define AVG_4_SAMPLES 0b00110000   // Perform 4 conversions and averages result
+#define AVG_8_SAMPLES 0b00110100   // Perform 8 conversions and averages result
+#define AVG_16_SAMPLES 0b00111000  // Perform 16 conversions and averages result
+#define AVG_32_SAMPLES 0b00111100  // Perform 32 conversions and averages result
+
+// Number of Scans (ONLY applicable of SCAN MODE 10 is set)
+#define NSCAN_4 0b00000000   // Scans channel N and returns 4 results
+#define NSCAN_8 0b00000001   // Scans channel N and returns 8 results
+#define NSCAN_16 0b00000010  // Scans channel N and returns 16 results
+#define NSCAN_32 0b00000011  // Scans channel N and returns 32 results
+
+/*******************************************************************************
+Reset Register
+*******************************************************************************/
+// Resets all registers
+#define RESET_REG 0b00010000
+// Resets FIFO registers only
+#define RESET_FIFO 0b00011000
+
+/*******************************************************************************
+additional commands
+*******************************************************************************/
+#define READ_ONLY 0b00000000

--- a/src/SPICurrentSense/SPICurrentSense.cpp
+++ b/src/SPICurrentSense/SPICurrentSense.cpp
@@ -19,17 +19,20 @@
  */
 SPICurrentSense::SPICurrentSense() {
   // Initializes instance of SPIClass attached to VSPI
+  delay(1);  // 1 ms second delay for ADC to boot
+  vspi = new SPIClass(VSPI);
   vspi->begin(VSPI_SCLK, VSPI_MISO, VSPI_MOSI, VSPI_SS);
   pinMode(EOC, INPUT);
+
   // set up slave select pins as outputs as the Arduino API
   // doesn't handle automatically pulling SS low
   pinMode(vspi->pinSS(), OUTPUT);  // VSPI SS
 
-  // Configures ADC on start up
-  // Conversions internally clocked, use external voltage reference
+  // Configured ADC behavior
+  SPITransmit(RESET_REG);  // Clears all ADC registers
+  // Use internal clock and external reference for conversions
   SPITransmit(INTERNAL_CLK | EXTERNAL_VREF);
-  // Disable averaging, single conversion mode
-  SPITransmit(AVG_DISABLE);
+  SPITransmit(AVG_DISABLE);  // Disable averaging, single conversion mode
 }
 
 /**
@@ -62,45 +65,46 @@ uint8_t SPICurrentSense::SPITransmit(byte data) {
  */
 void SPICurrentSense::readAllFingerCurrents() {
   // Requests signal data from all current sensors
-  SPITransmit(AIN0 | SCAN_N);  // Read thumb current sense circuit data
-  SPITransmit(AIN1 | SCAN_N);  // Read index current sense circuit data
-  SPITransmit(AIN2 | SCAN_N);  // Read middle current sense circuit data
-  SPITransmit(AIN3 | SCAN_N);  // Read ring current sense circuit data
-  SPITransmit(AIN4 | SCAN_N);  // Read pinky current sense circuit data
+  SPITransmit(AIN4 | SCAN_0N);  // Scans channels 0 through 4
 
   // Wait for all readings to be returned
-  uint8_t i = 0;
-  while (i < 5) {
-    if (digitalRead(EOC) == LOW) {
-      i++;
-      // Transmit no instructions, read ADC response
-      result1 = SPITransmit(READ_ONLY);
-      result2 = SPITransmit(READ_ONLY);
+  while (1) {
+    // Checks for conversions to be finished
+    if (digitalRead(EOC) == 0) {
+      // Serial.println("low"); // debugging check for EOC pin
+      // Reads
+      for (uint8_t i = 0; i < 5; i++) {
+        // Transmit no instructions, read ADC response
+        result1 = SPITransmit(READ_ONLY);
+        result2 = SPITransmit(READ_ONLY);
 
-      // Converts the two 8 bit responses to a single 16 bit value
-      rawResult = (result1 << 8) | result2;
-      // Converts raw data to voltage
-      rawResult = rawResult * (V_REF / RESOLUTION);
-      // Converts voltage to current
-      rawResult = (rawResult - 301.86) / 2.1;
+        // Converts the two 8 bit responses to a single 16 bit value
+        rawResult = (result1 << 8) | result2;
 
-      switch (i) {
-        case 0:  // Thumb
-          thumbCurrent = rawResult;
-          break;
-        case 1:  // Index finger
-          indexCurrent = rawResult;
-          break;
-        case 2:  // Middle finger
-          middleCurrent = rawResult;
-          break;
-        case 3:  // Ring finger
-          ringCurrent = rawResult;
-          break;
-        case 4:  // Pinky finger
-          pinkyCurrent = rawResult;
-          break;
+        // Converts raw data to voltage representation in mV
+        rawResult = rawResult * 3000 / RESOLUTION;
+
+        // Calculates and saves current to corresponding finger
+        switch (i) {
+          case 0:  // Thumb
+            thumbCurrent = (rawResult / 2.1) - thumbOffset;
+            break;
+          case 1:  // Index finger
+            indexCurrent = (rawResult / 2.1) - thumbOffset;
+            break;
+          case 2:  // Middle finger
+            middleCurrent = (rawResult / 2.1) - thumbOffset;
+            break;
+          case 3:  // Ring finger
+            ringCurrent = (rawResult / 2.1) - thumbOffset;
+            break;
+          case 4:  // Pinky finger
+            pinkyCurrent = (rawResult / 2.1) - thumbOffset;
+            break;
+        }
       }
+      // Breaks out of loop when ADC response is received
+      break;
     }
   }
 }
@@ -116,4 +120,25 @@ uint16_t SPICurrentSense::calculateTotalCurrent() {
       thumbCurrent + indexCurrent + middleCurrent + ringCurrent + pinkyCurrent;
 
   return totalCurrent;
+}
+
+/**
+ * @brief
+ *
+ * @param tmpThumbOffset
+ * @param tmpIndexOffset
+ * @param tmpMiddleOffset
+ * @param tmpRingOffset
+ * @param tmpPinkyOffset
+ */
+void SPICurrentSense::setCalibrationOffsets(uint16_t tmpThumbOffset,
+                                            uint16_t tmpIndexOffset,
+                                            uint16_t tmpMiddleOffset,
+                                            uint16_t tmpRingOffset,
+                                            uint16_t tmpPinkyOffset) {
+  thumbOffset = tmpThumbOffset;
+  indexOffset = tmpIndexOffset;
+  middleOffset = tmpMiddleOffset;
+  ringOffset = tmpRingOffset;
+  pinkyOffset = tmpPinkyOffset;
 }

--- a/src/SPICurrentSense/SPICurrentSense.cpp
+++ b/src/SPICurrentSense/SPICurrentSense.cpp
@@ -18,6 +18,9 @@
  *
  */
 SPICurrentSense::SPICurrentSense() {
+  // Initialize variables
+  calibrated = false;
+
   // Initializes instance of SPIClass attached to VSPI
   delay(1);  // 1 ms second delay for ADC to boot
   vspi = new SPIClass(VSPI);
@@ -88,37 +91,47 @@ void SPICurrentSense::readAllFingerCurrents() {
         // If current is a negative value it is overwritten to be 0
         switch (i) {
           case 0:  // Thumb
-            rawResult = (rawResult / 2.1) - thumbOffset;
-            if (rawResult < 0) {
-              rawResult = 0;
+            if (calibrated) {
+              rawResult = (rawResult - thumbOffset) / 2.1;
+              if (rawResult < 0) {
+                rawResult = 0;
+              }
             }
             thumbCurrent = rawResult;
             break;
           case 1:  // Index finger
-            rawResult = (rawResult / 2.1) - indexOffset;
-            if (rawResult < 0) {
-              rawResult = 0;
+            if (calibrated) {
+              rawResult = (rawResult - indexOffset) / 2.1;
+              if (rawResult < 0) {
+                rawResult = 0;
+              }
             }
             indexCurrent = rawResult;
             break;
           case 2:  // Middle finger
-            rawResult = (rawResult / 2.1) - middleOffset;
-            if (rawResult < 0) {
-              rawResult = 0;
+            if (calibrated) {
+              rawResult = (rawResult - middleOffset) / 2.1;
+              if (rawResult < 0) {
+                rawResult = 0;
+              }
             }
             middleCurrent = rawResult;
             break;
           case 3:  // Ring finger
-            rawResult = (rawResult / 2.1) - ringOffset;
-            if (rawResult < 0) {
-              rawResult = 0;
+            if (calibrated) {
+              rawResult = (rawResult - ringOffset) / 2.1;
+              if (rawResult < 0) {
+                rawResult = 0;
+              }
             }
             ringCurrent = rawResult;
             break;
           case 4:  // Pinky finger
-            rawResult = (rawResult / 2.1) - pinkyOffset;
-            if (rawResult < 0) {
-              rawResult = 0;
+            if (calibrated) {
+              rawResult = (rawResult - pinkyOffset) / 2.1;
+              if (rawResult < 0) {
+                rawResult = 0;
+              }
             }
             pinkyCurrent = rawResult;
             break;

--- a/src/SPICurrentSense/SPICurrentSense.cpp
+++ b/src/SPICurrentSense/SPICurrentSense.cpp
@@ -85,21 +85,42 @@ void SPICurrentSense::readAllFingerCurrents() {
         rawResult = rawResult * 3000 / RESOLUTION;
 
         // Calculates and saves current to corresponding finger
+        // If current is a negative value it is overwritten to be 0
         switch (i) {
           case 0:  // Thumb
-            thumbCurrent = (rawResult / 2.1) - thumbOffset;
+            rawResult = (rawResult / 2.1) - thumbOffset;
+            if (rawResult < 0) {
+              rawResult = 0;
+            }
+            thumbCurrent = rawResult;
             break;
           case 1:  // Index finger
-            indexCurrent = (rawResult / 2.1) - thumbOffset;
+            rawResult = (rawResult / 2.1) - indexOffset;
+            if (rawResult < 0) {
+              rawResult = 0;
+            }
+            indexCurrent = rawResult;
             break;
           case 2:  // Middle finger
-            middleCurrent = (rawResult / 2.1) - thumbOffset;
+            rawResult = (rawResult / 2.1) - middleOffset;
+            if (rawResult < 0) {
+              rawResult = 0;
+            }
+            middleCurrent = rawResult;
             break;
           case 3:  // Ring finger
-            ringCurrent = (rawResult / 2.1) - thumbOffset;
+            rawResult = (rawResult / 2.1) - ringOffset;
+            if (rawResult < 0) {
+              rawResult = 0;
+            }
+            ringCurrent = rawResult;
             break;
           case 4:  // Pinky finger
-            pinkyCurrent = (rawResult / 2.1) - thumbOffset;
+            rawResult = (rawResult / 2.1) - pinkyOffset;
+            if (rawResult < 0) {
+              rawResult = 0;
+            }
+            pinkyCurrent = rawResult;
             break;
         }
       }
@@ -123,13 +144,13 @@ uint16_t SPICurrentSense::calculateTotalCurrent() {
 }
 
 /**
- * @brief
+ * @brief Sets all current sense no load offsets for current calculations.
  *
- * @param tmpThumbOffset
- * @param tmpIndexOffset
- * @param tmpMiddleOffset
- * @param tmpRingOffset
- * @param tmpPinkyOffset
+ * @param tmpThumbOffset Thumb offset for current calculations
+ * @param tmpIndexOffset Index offset for current calculations
+ * @param tmpMiddleOffset Middle offset for current calculations
+ * @param tmpRingOffset Ring offset for current calculations
+ * @param tmpPinkyOffset Pinky offset for current calculations
  */
 void SPICurrentSense::setCalibrationOffsets(uint16_t tmpThumbOffset,
                                             uint16_t tmpIndexOffset,

--- a/src/SPICurrentSense/SPICurrentSense.cpp
+++ b/src/SPICurrentSense/SPICurrentSense.cpp
@@ -1,0 +1,119 @@
+/*
+ *  Prosthetic Arm Control (P.A.C) SPI Current Sense
+ *
+ *  Created on: 26 Feb, 2023
+ *      Author: Zachary Roberts
+ *
+ *      This library is used to manage the communication with the MAX11629EEE+
+ *      ADC, conversions, and calculations with the data from the Low End
+ *      Current sense circuit for each respective finger on the prosthetic arm
+ *      created in collaboration with York College of Pennsylvania
+ *      Capstone Course
+ */
+
+#include "SPICurrentSense.h"
+
+/**
+ * @brief Construct a new SPICurrentSense::SPICurrentSense object
+ *
+ */
+SPICurrentSense::SPICurrentSense() {
+  // Initializes instance of SPIClass attached to VSPI
+  vspi->begin(VSPI_SCLK, VSPI_MISO, VSPI_MOSI, VSPI_SS);
+  pinMode(EOC, INPUT);
+  // set up slave select pins as outputs as the Arduino API
+  // doesn't handle automatically pulling SS low
+  pinMode(vspi->pinSS(), OUTPUT);  // VSPI SS
+
+  // Configures ADC on start up
+  // Conversions internally clocked, use external voltage reference
+  SPITransmit(INTERNAL_CLK | EXTERNAL_VREF);
+  // Disable averaging, single conversion mode
+  SPITransmit(AVG_DISABLE);
+}
+
+/**
+ * @brief Transmits instructions to external ADC over SPI
+ *
+ * @param data unsigned 8 bit integer containing corresponding instruction
+ * @return uint8_t response from external ADC
+ */
+uint8_t SPICurrentSense::SPITransmit(byte data) {
+  uint8_t response;
+  vspi->beginTransaction(SPISettings(spiClk, MSBFIRST, SPI_MODE0));
+
+  // pull SS slow to prep other end for transfer
+  digitalWrite(vspi->pinSS(), LOW);
+
+  // Transmits SPI data
+  response = vspi->transfer(data);
+
+  // pull SS High to signify end of data transfer
+  digitalWrite(vspi->pinSS(), HIGH);
+  vspi->endTransaction();
+
+  return response;
+}
+
+/**
+ * @brief Reads current status of all current sensors. Converts raw data to
+ *        current in milliAmperes. Each reading is saved in it's respective
+ *        public variable
+ */
+void SPICurrentSense::readAllFingerCurrents() {
+  // Requests signal data from all current sensors
+  SPITransmit(AIN0 | SCAN_N);  // Read thumb current sense circuit data
+  SPITransmit(AIN1 | SCAN_N);  // Read index current sense circuit data
+  SPITransmit(AIN2 | SCAN_N);  // Read middle current sense circuit data
+  SPITransmit(AIN3 | SCAN_N);  // Read ring current sense circuit data
+  SPITransmit(AIN4 | SCAN_N);  // Read pinky current sense circuit data
+
+  // Wait for all readings to be returned
+  uint8_t i = 0;
+  while (i < 5) {
+    if (digitalRead(EOC) == LOW) {
+      i++;
+      // Transmit no instructions, read ADC response
+      result1 = SPITransmit(READ_ONLY);
+      result2 = SPITransmit(READ_ONLY);
+
+      // Converts the two 8 bit responses to a single 16 bit value
+      rawResult = (result1 << 8) | result2;
+      // Converts raw data to voltage
+      rawResult = rawResult * (V_REF / RESOLUTION);
+      // Converts voltage to current
+      rawResult = (rawResult - 301.86) / 2.1;
+
+      switch (i) {
+        case 0:  // Thumb
+          thumbCurrent = rawResult;
+          break;
+        case 1:  // Index finger
+          indexCurrent = rawResult;
+          break;
+        case 2:  // Middle finger
+          middleCurrent = rawResult;
+          break;
+        case 3:  // Ring finger
+          ringCurrent = rawResult;
+          break;
+        case 4:  // Pinky finger
+          pinkyCurrent = rawResult;
+          break;
+      }
+    }
+  }
+}
+
+/**
+ * @brief Adds all current values to calculate total servo current draw. Must
+ *        call readAllFIngerCurrents() first to ensure most up to date readings
+ *
+ * @return uint16_t Total combined current value of all current sense circuits
+ */
+uint16_t SPICurrentSense::calculateTotalCurrent() {
+  totalCurrent =
+      thumbCurrent + indexCurrent + middleCurrent + ringCurrent + pinkyCurrent;
+
+  return totalCurrent;
+}

--- a/src/SPICurrentSense/SPICurrentSense.h
+++ b/src/SPICurrentSense/SPICurrentSense.h
@@ -39,7 +39,7 @@ class SPICurrentSense {
   // ADC response
   uint8_t result1;
   uint8_t result2;
-  uint16_t rawResult;
+  int rawResult;
 
   // Current Sense Calibration offset values
   uint16_t thumbOffset;

--- a/src/SPICurrentSense/SPICurrentSense.h
+++ b/src/SPICurrentSense/SPICurrentSense.h
@@ -42,7 +42,7 @@ class SPICurrentSense {
   int rawResult;
 
   // Current Sense Calibration offset values
-  uint16_t thumbOffset;
+
   uint16_t indexOffset;
   uint16_t middleOffset;
   uint16_t ringOffset;
@@ -51,7 +51,7 @@ class SPICurrentSense {
  public:
   // Constructor
   SPICurrentSense();
-
+  uint16_t thumbOffset;
   // stores ADC reading current sensor
   uint16_t thumbCurrent;
   uint16_t indexCurrent;
@@ -59,6 +59,9 @@ class SPICurrentSense {
   uint16_t ringCurrent;
   uint16_t pinkyCurrent;
   uint16_t totalCurrent;
+
+  // Calibration toggle
+  bool calibrated;
 
   // function definitions
   uint8_t SPITransmit(byte data);

--- a/src/SPICurrentSense/SPICurrentSense.h
+++ b/src/SPICurrentSense/SPICurrentSense.h
@@ -42,11 +42,13 @@ class SPICurrentSense {
   int rawResult;
 
   // Current Sense Calibration offset values
-
   uint16_t indexOffset;
   uint16_t middleOffset;
   uint16_t ringOffset;
   uint16_t pinkyOffset;
+
+  // Timer to break out if SPI wait loop
+  hw_timer_t* timer = NULL;
 
  public:
   // Constructor

--- a/src/SPICurrentSense/SPICurrentSense.h
+++ b/src/SPICurrentSense/SPICurrentSense.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <Arduino.h>
+#include <SPI.h>
+// Include bit field SPI commands
+#include "MAX11629_SPICommands.h"
+
+// Used to identify which finger an object is to operate on
+#define FINGER_THUMB_CHANNEL 0
+#define FINGER_INDEX_CHANNEL 1
+#define FINGER_MIDDLE_CHANNEL 2
+#define FINGER_RING_CHANNEL 3
+#define FINGER_PINKY_CHANNEL 4
+
+// SPI Configuration
+#if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#define VSPI
+#endif
+
+// SPI Pins
+#define VSPI_MOSI 35
+#define VSPI_MISO 37
+#define VSPI_SCLK 36
+#define VSPI_SS 34
+
+// End of Conversion pin
+#define EOC 33
+
+// ADC configruation
+#define V_REF 3
+#define RESOLUTION 4096
+
+class SPICurrentSense {
+ private:
+  // spi configuration
+  static const int spiClk = 10000000;  // 10 MHz
+  SPIClass* vspi = NULL;
+
+  // ADC response
+  uint8_t result1;
+  uint8_t result2;
+  uint16_t rawResult;
+
+ public:
+  // Constructor
+  SPICurrentSense();
+
+  // stores ADC reading current sensor
+  uint16_t thumbCurrent;
+  uint16_t indexCurrent;
+  uint16_t middleCurrent;
+  uint16_t ringCurrent;
+  uint16_t pinkyCurrent;
+  uint16_t totalCurrent;
+
+  // function definitions
+  uint8_t SPITransmit(byte data);
+  void readAllFingerCurrents();
+  uint16_t calculateTotalCurrent();
+};

--- a/src/SPICurrentSense/SPICurrentSense.h
+++ b/src/SPICurrentSense/SPICurrentSense.h
@@ -27,7 +27,7 @@
 #define EOC 33
 
 // ADC configruation
-#define V_REF 3
+#define V_REF_3V 3000  // 3 V regerence = 3000 mV
 #define RESOLUTION 4096
 
 class SPICurrentSense {
@@ -40,6 +40,13 @@ class SPICurrentSense {
   uint8_t result1;
   uint8_t result2;
   uint16_t rawResult;
+
+  // Current Sense Calibration offset values
+  uint16_t thumbOffset;
+  uint16_t indexOffset;
+  uint16_t middleOffset;
+  uint16_t ringOffset;
+  uint16_t pinkyOffset;
 
  public:
   // Constructor
@@ -57,4 +64,7 @@ class SPICurrentSense {
   uint8_t SPITransmit(byte data);
   void readAllFingerCurrents();
   uint16_t calculateTotalCurrent();
+  void setCalibrationOffsets(uint16_t tmpThumbOffset, uint16_t tmpIndexOffset,
+                             uint16_t tmpMiddleOffset, uint16_t tmpRingOffset,
+                             uint16_t tmpPinkyOffset);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,12 +150,12 @@ void emg_callback(BLERemoteCharacteristic *pBLERemoteCharacteristic,
 
   // Pushes data to inter-core buffer
   // If Queue is full for longer than 10 ms, clear the buffer and push new data
-  if (xQueueSend(xQueue, &tempBuffer1, 10) == false) {
+  if (xQueueSend(xQueue, &tempBuffer1, 10) == errQUEUE_FULL) {
     xQueueReset(xQueue);
     xQueueSend(xQueue, &tempBuffer1, 0);
   }
 
-  if (xQueueSend(xQueue, &tempBuffer2, 10) == false) {
+  if (xQueueSend(xQueue, &tempBuffer2, 10) == errQUEUE_FULL) {
     xQueueReset(xQueue);
     xQueueSend(xQueue, &tempBuffer2, 0);
   }


### PR DESCRIPTION
Adds support for all communication capabilities unique to REV 2.1 of the PCB. Along with all necessary functions to process the acquired data.
- BLE to acquire EMG data from myo armband
-- Multi core proccessing
-- Mean Absolute Value (MAV) data processing 
--- Temporary, will replace MAV with a Machine Learning model in the near future
- SPI to acquire data readings from the Current sense circuit
-- Bitfields for all SPI commands accepted by the MAX11629EEE+ ADC
-- Calculate total and individual channel currents
Calibration on boot was also implemented for the current sense circuits to prevent offset errors from impacting current readings.